### PR TITLE
added 'top' and 'dump' commands

### DIFF
--- a/Profiler/Impl/ProfilerCommands.cs
+++ b/Profiler/Impl/ProfilerCommands.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Torch;
+using Torch.Commands;
+using Torch.API.Managers;
+
+namespace Profiler.Impl
+{
+    [Category("profiler")]
+    public class ProfilerCommands : CommandModule
+    {
+        [Command("dump", "Dumps the profiler data into the default dump file.")]
+        public void Dump() => DumpTo("profiler_dump.xml");
+
+        [Command("dump to", "Dumps the profiler data into the specified file.", "Dumps the profiler data into the specified file.\nExample: !profiler dump to myfile.dmp")]
+        public void DumpTo(string filename)
+        {
+            TorchBase.Instance?.Managers.GetManager<ProfilerManager>()?.DumpToFile(System.IO.Path.Combine(TorchBase.Instance.Config.InstancePath, filename));
+            Context.Respond($"Dump saved to {filename}.");
+        }
+
+        [Command("top", "List the top N entities by usage time", "List the top N entities by usage time\nReturns only leaf nodes, ie. entities with no child entities.\nExample: !profiler top 10")]
+        public void Top(int n)
+        {
+            Context.Respond(String.Join("\n", ProfilerData.GetTopEntityUpdateTimes().Take(n).Select(x => $"{x.Item1}: {(x.Item2 * 1000):0.0000}ms")));
+        }
+    }
+}

--- a/Profiler/Profiler.csproj
+++ b/Profiler/Profiler.csproj
@@ -141,6 +141,7 @@
       <Link>Properties\AssemblyVersion.cs</Link>
     </Compile>
     <Compile Include="Api\IProfilerEntryViewModel.cs" />
+    <Compile Include="Impl\ProfilerCommands.cs" />
     <Compile Include="Impl\FatProfilerEntry.cs" />
     <Compile Include="Impl\ProfilerBlock.cs" />
     <Compile Include="Impl\ProfilerData.cs" />


### PR DESCRIPTION
Since my server is hosted, I cannot have access to Torch GUI, therefore these commands would make it possible for me to use the Profiler plugin.

New comands:
- `dump`: dumps profile data to default file
- `dump to`: dumps profile data to the specified file
- `top`: gets the top N entities by usage time and lists them in the chat window (it flattens the profiler data tree, sends only leaf nodes)