### PR TITLE
check for .sbm file extension on --mod

### DIFF
--- a/Profiler/ProfilerCommands.cs
+++ b/Profiler/ProfilerCommands.cs
@@ -259,7 +259,7 @@ namespace Profiler
                     {
                         var ctx = new MyModContext();
                         ctx.Init(mod);
-                        if (ctx.ModId.Equals(nam, StringComparison.OrdinalIgnoreCase) || ctx.ModId.Equals(nam + ".sbm", StringComparison.OrdinalIgnoreCase))
+                        if (ctx.ModId.Equals(nam, StringComparison.OrdinalIgnoreCase) || ctx.ModId.Equals(nam + ".sbm", StringComparison.OrdinalIgnoreCase) || ctx.ModName.Equals(nam, StringComparison.OrdinalIgnoreCase))
                         {
                             modFilter = ctx;
                             break;

--- a/Profiler/ProfilerCommands.cs
+++ b/Profiler/ProfilerCommands.cs
@@ -259,7 +259,7 @@ namespace Profiler
                     {
                         var ctx = new MyModContext();
                         ctx.Init(mod);
-                        if (ctx.ModId.Equals(nam, StringComparison.OrdinalIgnoreCase) || ctx.ModName.Equals(nam, StringComparison.OrdinalIgnoreCase))
+                        if (ctx.ModId.Equals(nam, StringComparison.OrdinalIgnoreCase) || ctx.ModId.Equals(nam + ".sbm", StringComparison.OrdinalIgnoreCase))
                         {
                             modFilter = ctx;
                             break;


### PR DESCRIPTION
According to the source code, the string ModId includes the .sbm file extension ((publishedFileId.ToString() + ".sbm"));), tested in-game as well. Also, ModName is practically useless to try and parse, since any space in the parameter is not included since we're only taking the first word since arg can't have spaces (arg.Substring("--mod=".Length);) and most mod names have spaces in them, and the help context on line 134 says to use only the ID anyway.