### PR TITLE
Take Stopwatch.Frequency

### DIFF
--- a/Profiler/Core/ProfilerToken.cs
+++ b/Profiler/Core/ProfilerToken.cs
@@ -11,7 +11,7 @@ namespace Profiler.Core
         public readonly object GameEntity;
         public readonly int MethodIndex;
         public readonly ProfilerCategory Category;
-        public readonly long StartTick; // in 100 nanoseconds
+        public readonly long StartTick; // depends on Stopwatch.Frequency
 
         internal ProfilerToken(object gameEntity, int methodIndex, ProfilerCategory category)
         {


### PR DESCRIPTION
- Fix `Stopwatch.Frequency` not taken into account, making results inconsistent across different systems
- Fix `ProfilerEntry.MainThreadTime` with rounding error accumulated