### PR TITLE
Profile MySessionComponentBase.UpdatedBeforeInit

### DIFF
--- a/Profiler/Core.Patches/MySession_UpdateComponents_Transpile.cs
+++ b/Profiler/Core.Patches/MySession_UpdateComponents_Transpile.cs
@@ -26,6 +26,7 @@ namespace Profiler.Core.Patches
 
         static readonly ProfileBeginTokenTarget[] TargetCalls =
         {
+            new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdatedBeforeInit), UpdateSessionComponentsCategoryTokenMethod),
             new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdateBeforeSimulation), UpdateSessionComponentsCategoryTokenMethod),
             new ProfileBeginTokenTarget(typeof(MyReplicationLayer), nameof(MyReplicationLayer.Simulate), UpdateReplicationCategoryTokenMethod),
             new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.Simulate), UpdateSessionComponentsCategoryTokenMethod),

--- a/Profiler/Core.Patches/MySession_UpdateComponents_Transpile.cs
+++ b/Profiler/Core.Patches/MySession_UpdateComponents_Transpile.cs
@@ -24,24 +24,19 @@ namespace Profiler.Core.Patches
         static readonly MethodInfo UpdateSessionComponentsCategoryTokenMethod = SelfType.GetStaticMethod(nameof(CreateTokenInUpdateSessionComponentsCategory));
         static readonly MethodInfo UpdateReplicationCategoryTokenMethod = SelfType.GetStaticMethod(nameof(CreateTokenInUpdateReplicationCategory));
 
-        static readonly (Type Type, string Method, MethodInfo TokenCreataor)[] TargetCalls =
+        static readonly ProfileBeginTokenTarget[] TargetCalls =
         {
-            (typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdateBeforeSimulation), UpdateSessionComponentsCategoryTokenMethod),
-            (typeof(MyReplicationLayer), nameof(MyReplicationLayer.Simulate), UpdateReplicationCategoryTokenMethod),
-            (typeof(MySessionComponentBase), nameof(MySessionComponentBase.Simulate), UpdateSessionComponentsCategoryTokenMethod),
-            (typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdateAfterSimulation), UpdateSessionComponentsCategoryTokenMethod),
+            new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdateBeforeSimulation), UpdateSessionComponentsCategoryTokenMethod),
+            new ProfileBeginTokenTarget(typeof(MyReplicationLayer), nameof(MyReplicationLayer.Simulate), UpdateReplicationCategoryTokenMethod),
+            new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.Simulate), UpdateSessionComponentsCategoryTokenMethod),
+            new ProfileBeginTokenTarget(typeof(MySessionComponentBase), nameof(MySessionComponentBase.UpdateAfterSimulation), UpdateSessionComponentsCategoryTokenMethod),
         };
-
-        static bool Matches(MethodBase method, Type type, string name)
-        {
-            return method.DeclaringType == type && method.Name == name;
-        }
-
+        
         static bool TryGetTokenCreatorMethod(MethodBase method, out MethodInfo tokenCreatorMethod)
         {
-            if (TargetCalls.TryGetFirst(c => Matches(method, c.Type, c.Method), out var call))
+            if (TargetCalls.TryGetFirst(c => c.Matches(method), out var call))
             {
-                tokenCreatorMethod = call.TokenCreataor;
+                tokenCreatorMethod = call.TokenCreator;
                 return true;
             }
 

--- a/Profiler/Core.Patches/ProfileBeginTokenTarget.cs
+++ b/Profiler/Core.Patches/ProfileBeginTokenTarget.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Reflection;
+
+namespace Profiler.Core.Patches
+{
+    // just an alternative value tupple for v4.6
+    public sealed class ProfileBeginTokenTarget
+    {
+        public ProfileBeginTokenTarget(Type type, string method, MethodInfo tokenCreator)
+        {
+            Type = type;
+            Method = method;
+            TokenCreator = tokenCreator;
+        }
+
+        public Type Type { get; }
+        public string Method { get; }
+        public MethodInfo TokenCreator { get; }
+
+        public bool Matches(MethodBase method)
+        {
+            return method.DeclaringType == Type && method.Name == Method;
+        }
+    }
+}

--- a/Profiler/Profiler.csproj
+++ b/Profiler/Profiler.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Core.Patches\MySession_UpdateComponents.cs" />
     <Compile Include="Core.Patches\MySession_UpdateComponents_Transpile.cs" />
     <Compile Include="Core.Patches\MyTransportLayer_Tick.cs" />
+    <Compile Include="Core.Patches\ProfileBeginTokenTarget.cs" />
     <Compile Include="Core\IProfiler.cs" />
     <Compile Include="Core\StringIndexer.cs" />
     <Compile Include="Core\ProfilerCategory.cs" />


### PR DESCRIPTION
* Added a method in the game that was missing from the profiler's scope.
* Removed use of ValueTupple because the project's framework version is below v4.7. 

The missing method was missing because I was thinking it wasn't doing any calculation. Apparently some mods do implement the method.