### PR TITLE
Fix profiler running when nobody is consuming the profiler data

### DIFF
--- a/Profiler/Core/ProfilerResultQueue.cs
+++ b/Profiler/Core/ProfilerResultQueue.cs
@@ -35,6 +35,8 @@ namespace Profiler.Core
 
         internal static void Enqueue(in ProfilerResult result)
         {
+            if (_profilers.Count == 0) return;
+
             _profilerResults.Enqueue(result);
         }
 


### PR DESCRIPTION
This request will fix the issue where the profiler was causing unnecessary GC's when no `IProfiler` was present to consume the data.

This check was missing because I was assuming that there would always be some consumers throughout the session (for my Torch Monitor tool) 