### PR TITLE
Fix crash on GetTopEntities()

### DIFF
--- a/Profiler/Basics/BaseProfilerResult.cs
+++ b/Profiler/Basics/BaseProfilerResult.cs
@@ -51,7 +51,10 @@ namespace Profiler.Basics
         /// <returns>Sorted entities per their profiled time, descending.</returns>
         public IEnumerable<KeyedEntity> GetTopEntities(int? limit = null)
         {
-            return _entities
+            //https://stackoverflow.com/questions/11692389
+            var entities = _entities.ToArray();
+            
+            return entities
                 .OrderByDescending(r => r.Value.TotalTime)
                 .Select(kv => new KeyedEntity(kv.Key, kv.Value))
                 .Take(limit ?? int.MaxValue)


### PR DESCRIPTION
reported here:
https://discordapp.com/channels/790909018897907762/790939031260102666/867575889256775690

    11:00:15.8672 [ERROR]  TorchMonitor.ProfilerMonitors.PhysicsProfilerMonitor: System.ArgumentException: The index is equal to or greater than the length of the array, or the number of elements in the dictionary is greater than the available space from index to the end of the destination array.
         at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(KeyValuePair`2[] array, Int32 index)
         at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
         at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
         at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
         at System.Linq.Enumerable.<TakeIterator>d__25`1.MoveNext()
         at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
         at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
         at Profiler.Basics.BaseProfilerResult`1.GetTopEntities(Nullable`1 limit) in C:\build\workspace\Torch_Profiler_master\Profiler\Basics\BaseProfilerResult.cs:line 54
         at TorchMonitor.ProfilerMonitors.PhysicsProfilerMonitor.ProcessResult(BaseProfilerResult`1 result)
         at TorchMonitor.ProfilerMonitors.PhysicsProfilerMonitor.<Profile>d__6.MoveNext()
    --- End of stack trace from previous location where exception was thrown ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
         at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
         at Utils.General.TaskUtils.<Forget>d__0.MoveNext()